### PR TITLE
Wrap payload with notification key for proper notification rendering

### DIFF
--- a/src/WebPushChannel.php
+++ b/src/WebPushChannel.php
@@ -33,8 +33,9 @@ class WebPushChannel
         if (! $subscriptions || $subscriptions->isEmpty()) {
             return;
         }
-
-        $payload = json_encode($notification->toWebPush($notifiable, $notification)->toArray());
+        
+        $payload = ['notification' => $notification->toWebPush($notifiable, $notification)->toArray()];
+        $payload = json_encode($payload);
 
         $subscriptions->each(function ($sub) use ($payload) {
             $this->webPush->sendNotification(


### PR DESCRIPTION
Fixes the "Site has updated in the background" notification from Chrome as outlined in Issue https://github.com/laravel-notification-channels/webpush/issues/73